### PR TITLE
Headers hierarchy don't enforce class constraint on value

### DIFF
--- a/src/DotNetty.Codecs.Http/CombinedHttpHeaders.cs
+++ b/src/DotNetty.Codecs.Http/CombinedHttpHeaders.cs
@@ -155,8 +155,7 @@ namespace DotNetty.Codecs.Http
 
             CombinedHttpHeadersImpl AddEscapedValue(AsciiString name, ICharSequence escapedValue)
             {
-                ICharSequence currentValue = this.Get(name);
-                if (currentValue == null)
+                if (!this.TryGet(name, out ICharSequence currentValue))
                 {
                     base.Add(name, escapedValue);
                 }

--- a/src/DotNetty.Codecs.Http/Cors/CorsHandler.cs
+++ b/src/DotNetty.Codecs.Http/Cors/CorsHandler.cs
@@ -72,8 +72,7 @@ namespace DotNetty.Codecs.Http.Cors
 
         bool SetOrigin(IHttpResponse response)
         {
-            ICharSequence origin = this.request.Headers.Get(HttpHeaderNames.Origin);
-            if (origin == null)
+            if (!this.request.Headers.TryGet(HttpHeaderNames.Origin, out ICharSequence origin))
             {
                 return false;
             }
@@ -113,8 +112,7 @@ namespace DotNetty.Codecs.Http.Cors
                 return true;
             }
 
-            ICharSequence origin = this.request.Headers.Get(HttpHeaderNames.Origin);
-            if (origin == null)
+            if (!this.request.Headers.TryGet(HttpHeaderNames.Origin, out ICharSequence origin))
             {
                 // Not a CORS request so we cannot validate it. It may be a non CORS request.
                 return true;
@@ -127,7 +125,7 @@ namespace DotNetty.Codecs.Http.Cors
             return this.config.Origins.Contains(origin);
         }
 
-        void EchoRequestOrigin(IHttpResponse response) => SetOrigin(response, this.request.Headers.Get(HttpHeaderNames.Origin));
+        void EchoRequestOrigin(IHttpResponse response) => SetOrigin(response, this.request.Headers.Get(HttpHeaderNames.Origin, null));
 
         static void SetVaryHeader(IHttpResponse response) => response.Headers.Set(HttpHeaderNames.Vary, HttpHeaderNames.Origin);
 
@@ -140,7 +138,7 @@ namespace DotNetty.Codecs.Http.Cors
         void SetAllowCredentials(IHttpResponse response)
         {
             if (this.config.IsCredentialsAllowed 
-                && !AsciiString.ContentEquals(response.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin), AnyOrigin))
+                && !AsciiString.ContentEquals(response.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin, null), AnyOrigin))
             {
                 response.Headers.Set(HttpHeaderNames.AccessControlAllowCredentials, new AsciiString("true"));
             }

--- a/src/DotNetty.Codecs.Http/DefaultHttpHeaders.cs
+++ b/src/DotNetty.Codecs.Http/DefaultHttpHeaders.cs
@@ -150,17 +150,17 @@ namespace DotNetty.Codecs.Http
             return this;
         }
 
-        public override ICharSequence Get(AsciiString name) => this.headers.Get(name);
+        public override bool TryGet(AsciiString name, out ICharSequence value) => this.headers.TryGet(name, out value);
 
-        public override int? GetInt(AsciiString name) => this.headers.GetInt(name);
+        public override bool TryGetInt(AsciiString name, out int value) => this.headers.TryGetInt(name, out value);
 
         public override int GetInt(AsciiString name, int defaultValue) => this.headers.GetInt(name, defaultValue);
 
-        public override short? GetShort(AsciiString name) => this.headers.GetShort(name);
+        public override bool TryGetShort(AsciiString name, out short value) => this.headers.TryGetShort(name, out value);
 
         public override short GetShort(AsciiString name, short defaultValue) => this.headers.GetShort(name, defaultValue);
 
-        public override long? GetTimeMillis(AsciiString name) => this.headers.GetTimeMillis(name);
+        public override bool TryGetTimeMillis(AsciiString name, out long value) => this.headers.TryGetTimeMillis(name, out value);
 
         public override long GetTimeMillis(AsciiString name, long defaultValue) => this.headers.GetTimeMillis(name, defaultValue);
 

--- a/src/DotNetty.Codecs.Http/EmptyHttpHeaders.cs
+++ b/src/DotNetty.Codecs.Http/EmptyHttpHeaders.cs
@@ -20,17 +20,33 @@ namespace DotNetty.Codecs.Http
         {
         }
 
-        public override ICharSequence Get(AsciiString name) => null;
+        public override bool TryGet(AsciiString name, out ICharSequence value)
+        {
+            value = default(ICharSequence);
+            return false;
+        }
 
-        public override int? GetInt(AsciiString name) => null;
+        public override bool TryGetInt(AsciiString name, out int value)
+        {
+            value = default(int);
+            return false;
+        }
 
         public override int GetInt(AsciiString name, int defaultValue) => defaultValue;
 
-        public override short? GetShort(AsciiString name) => null;
+        public override bool TryGetShort(AsciiString name, out short value)
+        {
+            value = default(short);
+            return false;
+        }
 
         public override short GetShort(AsciiString name, short defaultValue) => defaultValue;
 
-        public override long? GetTimeMillis(AsciiString name) => null;
+        public override bool TryGetTimeMillis(AsciiString name, out long value)
+        {
+            value = default(long);
+            return false;
+        }
 
         public override long GetTimeMillis(AsciiString name, long defaultValue) => defaultValue;
 

--- a/src/DotNetty.Codecs.Http/HttpClientUpgradeHandler.cs
+++ b/src/DotNetty.Codecs.Http/HttpClientUpgradeHandler.cs
@@ -142,8 +142,7 @@ namespace DotNetty.Codecs.Http
                     response = (IFullHttpResponse)output[0];
                 }
 
-                ICharSequence upgradeHeader = response.Headers.Get(HttpHeaderNames.Upgrade);
-                if (upgradeHeader != null && !AsciiString.ContentEqualsIgnoreCase(this.upgradeCodec.Protocol, upgradeHeader))
+                if (response.Headers.TryGet(HttpHeaderNames.Upgrade, out ICharSequence upgradeHeader) && !AsciiString.ContentEqualsIgnoreCase(this.upgradeCodec.Protocol, upgradeHeader))
                 {
                     throw new  InvalidOperationException($"Switching Protocols response with unexpected UPGRADE protocol: {upgradeHeader}");
                 }

--- a/src/DotNetty.Codecs.Http/HttpContentCompressor.cs
+++ b/src/DotNetty.Codecs.Http/HttpContentCompressor.cs
@@ -44,8 +44,7 @@ namespace DotNetty.Codecs.Http
 
         protected override Result BeginEncode(IHttpResponse headers, ICharSequence acceptEncoding)
         {
-            ICharSequence contentEncoding = headers.Headers.Get(HttpHeaderNames.ContentEncoding);
-            if (contentEncoding != null)
+            if (headers.Headers.Contains(HttpHeaderNames.ContentEncoding))
             {
                 // Content-Encoding was set, either as something specific or as the IDENTITY encoding
                 // Therefore, we should NOT encode here

--- a/src/DotNetty.Codecs.Http/HttpContentDecoder.cs
+++ b/src/DotNetty.Codecs.Http/HttpContentDecoder.cs
@@ -48,8 +48,7 @@ namespace DotNetty.Codecs.Http
                 HttpHeaders headers = httpMessage.Headers;
 
                 // Determine the content encoding.
-                ICharSequence contentEncoding = headers.Get(HttpHeaderNames.ContentEncoding);
-                if (contentEncoding != null)
+                if (headers.TryGet(HttpHeaderNames.ContentEncoding, out ICharSequence contentEncoding))
                 {
                     contentEncoding = AsciiString.Trim(contentEncoding);
                 }

--- a/src/DotNetty.Codecs.Http/HttpContentEncoder.cs
+++ b/src/DotNetty.Codecs.Http/HttpContentEncoder.cs
@@ -33,8 +33,7 @@ namespace DotNetty.Codecs.Http
 
         protected override void Decode(IChannelHandlerContext ctx, IHttpRequest msg, List<object> output)
         {
-            ICharSequence acceptedEncoding = msg.Headers.Get(HttpHeaderNames.AcceptEncoding)
-                ?? HttpContentDecoder.Identity;
+            ICharSequence acceptedEncoding = msg.Headers.Get(HttpHeaderNames.AcceptEncoding, HttpContentDecoder.Identity);
 
             HttpMethod meth = msg.Method;
             if (ReferenceEquals(meth, HttpMethod.Head))

--- a/src/DotNetty.Codecs.Http/HttpHeaders.cs
+++ b/src/DotNetty.Codecs.Http/HttpHeaders.cs
@@ -13,19 +13,19 @@ namespace DotNetty.Codecs.Http
 
     public abstract class HttpHeaders : IEnumerable<HeaderEntry<AsciiString, ICharSequence>>
     {
-        public abstract ICharSequence Get(AsciiString name);
+        public abstract bool TryGet(AsciiString name, out ICharSequence value);
 
-        public ICharSequence Get(AsciiString name, ICharSequence defaultValue) => this.Get(name) ?? defaultValue;
+        public ICharSequence Get(AsciiString name, ICharSequence defaultValue) => this.TryGet(name, out ICharSequence value) ? value : defaultValue;
 
-        public abstract int? GetInt(AsciiString name);
+        public abstract bool TryGetInt(AsciiString name, out int value);
 
         public abstract int GetInt(AsciiString name, int defaultValue);
 
-        public abstract short? GetShort(AsciiString name);
+        public abstract bool TryGetShort(AsciiString name, out short value);
 
         public abstract short GetShort(AsciiString name, short defaultValue);
 
-        public abstract long? GetTimeMillis(AsciiString name);
+        public abstract bool TryGetTimeMillis(AsciiString name, out long value);
 
         public abstract long GetTimeMillis(AsciiString name, long defaultValue);
 
@@ -221,7 +221,19 @@ namespace DotNetty.Codecs.Http
             return false;
         }
 
-        public string GetAsString(AsciiString name) => this.Get(name).ToString();
+        public bool TryGetAsString(AsciiString name, out string value)
+        {
+            if (this.TryGet(name, out ICharSequence v))
+            {
+                value = v.ToString();
+                return true;
+            }
+            else
+            {
+                value = default(string);
+                return false;
+            }
+        }
 
         public IList<string> GetAllAsString(AsciiString name)
         {

--- a/src/DotNetty.Codecs.Http/HttpObjectDecoder.cs
+++ b/src/DotNetty.Codecs.Http/HttpObjectDecoder.cs
@@ -453,8 +453,8 @@ namespace DotNetty.Codecs.Http
             {
                 return false;
             }
-            ICharSequence newProtocol = msg.Headers.Get(HttpHeaderNames.Upgrade);
-            return newProtocol == null 
+
+            return !msg.Headers.TryGet(HttpHeaderNames.Upgrade, out ICharSequence newProtocol)
                 || !AsciiString.Contains(newProtocol, HttpVersion.Http10String) 
                    && !AsciiString.Contains(newProtocol, HttpVersion.Http11String);
         }

--- a/src/DotNetty.Codecs.Http/HttpServerKeepAliveHandler.cs
+++ b/src/DotNetty.Codecs.Http/HttpServerKeepAliveHandler.cs
@@ -91,8 +91,7 @@ namespace DotNetty.Codecs.Http
 
         static bool IsMultipart(IHttpResponse response)
         {
-            ICharSequence contentType = response.Headers.Get(HttpHeaderNames.ContentType);
-            return contentType != null 
+            return response.Headers.TryGet(HttpHeaderNames.ContentType, out ICharSequence contentType)
                 && contentType.RegionMatchesIgnoreCase(0, MultipartPrefix, 0, MultipartPrefix.Count);
         }
     }

--- a/src/DotNetty.Codecs.Http/HttpServerUpgradeHandler.cs
+++ b/src/DotNetty.Codecs.Http/HttpServerUpgradeHandler.cs
@@ -190,13 +190,13 @@ namespace DotNetty.Codecs.Http
             {
                 return false;
             }
-            return request.Headers.Get(HttpHeaderNames.Upgrade) != null;
+            return request.Headers.Contains(HttpHeaderNames.Upgrade);
         }
 
         bool Upgrade(IChannelHandlerContext ctx, IFullHttpRequest request)
         {
             // Select the best protocol based on those requested in the UPGRADE header.
-            IList<ICharSequence> requestedProtocols = SplitHeader(request.Headers.Get(HttpHeaderNames.Upgrade));
+            IList<ICharSequence> requestedProtocols = SplitHeader(request.Headers.Get(HttpHeaderNames.Upgrade, null));
             int numRequestedProtocols = requestedProtocols.Count;
             IUpgradeCodec upgradeCodec = null;
             ICharSequence upgradeProtocol = null;
@@ -219,8 +219,8 @@ namespace DotNetty.Codecs.Http
             }
 
             // Make sure the CONNECTION header is present.
-            ICharSequence connectionHeader = request.Headers.Get(HttpHeaderNames.Connection);
-            if (connectionHeader == null)
+            ;
+            if (!request.Headers.TryGet(HttpHeaderNames.Connection, out ICharSequence connectionHeader))
             {
                 return false;
             }

--- a/src/DotNetty.Codecs.Http/HttpUtil.cs
+++ b/src/DotNetty.Codecs.Http/HttpUtil.cs
@@ -15,8 +15,8 @@ namespace DotNetty.Codecs.Http
 
         public static bool IsKeepAlive(IHttpMessage message)
         {
-            ICharSequence connection = message.Headers.Get(HttpHeaderNames.Connection);
-            if (connection != null && HttpHeaderValues.Close.ContentEqualsIgnoreCase(connection))
+            if (message.Headers.TryGet(HttpHeaderNames.Connection, out ICharSequence connection) 
+                && HttpHeaderValues.Close.ContentEqualsIgnoreCase(connection))
             {
                 return false;
             }
@@ -61,8 +61,7 @@ namespace DotNetty.Codecs.Http
 
         public static long GetContentLength(IHttpMessage message)
         {
-            ICharSequence value = message.Headers.Get(HttpHeaderNames.ContentLength);
-            if (value != null)
+            if (message.Headers.TryGet(HttpHeaderNames.ContentLength, out ICharSequence value))
             {
                 return CharUtil.ParseLong(value);
             }
@@ -81,8 +80,7 @@ namespace DotNetty.Codecs.Http
 
         public static long GetContentLength(IHttpMessage message, long defaultValue)
         {
-            ICharSequence value = message.Headers.Get(HttpHeaderNames.ContentLength);
-            if (value != null)
+            if (message.Headers.TryGet(HttpHeaderNames.ContentLength, out ICharSequence value))
             {
                 return CharUtil.ParseLong(value);
             }
@@ -140,7 +138,7 @@ namespace DotNetty.Codecs.Http
                 return false;
             }
 
-            ICharSequence expectValue = message.Headers.Get(HttpHeaderNames.Expect);
+            ICharSequence expectValue = message.Headers.Get(HttpHeaderNames.Expect, null);
             // unquoted tokens in the expect header are case-insensitive, thus 100-continue is case insensitive
             return HttpHeaderValues.Continue.ContentEqualsIgnoreCase(expectValue);
         }
@@ -152,8 +150,8 @@ namespace DotNetty.Codecs.Http
                 return false;
             }
 
-            ICharSequence expectValue = message.Headers.Get(HttpHeaderNames.Expect);
-            return expectValue != null && !HttpHeaderValues.Continue.ContentEqualsIgnoreCase(expectValue);
+            return message.Headers.TryGet(HttpHeaderNames.Expect, out ICharSequence expectValue) 
+                && !HttpHeaderValues.Continue.ContentEqualsIgnoreCase(expectValue);
         }
 
         // Expect: 100-continue is for requests only and it works only on HTTP/1.1 or later. Note further that RFC 7231
@@ -215,8 +213,9 @@ namespace DotNetty.Codecs.Http
 
         public static Encoding GetCharset(IHttpMessage message, Encoding defaultCharset)
         {
-            ICharSequence contentTypeValue = message.Headers.Get(HttpHeaderNames.ContentType);
-            return contentTypeValue != null ? GetCharset(contentTypeValue, defaultCharset) : defaultCharset;
+            return message.Headers.TryGet(HttpHeaderNames.ContentType, out ICharSequence contentTypeValue) 
+                ? GetCharset(contentTypeValue, defaultCharset) 
+                : defaultCharset;
         }
 
         public static Encoding GetCharset(ICharSequence contentTypeValue, Encoding defaultCharset)
@@ -246,11 +245,8 @@ namespace DotNetty.Codecs.Http
             }
         }
 
-        public static ICharSequence GetCharsetAsSequence(IHttpMessage message)
-        {
-            ICharSequence contentTypeValue = message.Headers.Get(HttpHeaderNames.ContentType);
-            return contentTypeValue != null ? GetCharsetAsSequence(contentTypeValue) : null;
-        }
+        public static ICharSequence GetCharsetAsSequence(IHttpMessage message) 
+            => message.Headers.TryGet(HttpHeaderNames.ContentType, out ICharSequence contentTypeValue) ? GetCharsetAsSequence(contentTypeValue) : null;
 
         public static ICharSequence GetCharsetAsSequence(ICharSequence contentTypeValue)
         {
@@ -270,11 +266,8 @@ namespace DotNetty.Codecs.Http
             return null;
         }
 
-        public static ICharSequence GetMimeType(IHttpMessage message)
-        {
-            ICharSequence contentTypeValue = message.Headers.Get(HttpHeaderNames.ContentType);
-            return contentTypeValue != null ? GetMimeType(contentTypeValue) : null;
-        }
+        public static ICharSequence GetMimeType(IHttpMessage message) => 
+            message.Headers.TryGet(HttpHeaderNames.ContentType, out ICharSequence contentTypeValue) ? GetMimeType(contentTypeValue) : null;
 
         public static ICharSequence GetMimeType(ICharSequence contentTypeValue)
         {

--- a/src/DotNetty.Codecs.Http/Multipart/HttpPostMultipartRequestDecoder.cs
+++ b/src/DotNetty.Codecs.Http/Multipart/HttpPostMultipartRequestDecoder.cs
@@ -82,7 +82,7 @@ namespace DotNetty.Codecs.Http.Multipart
             this.charset = charset;
 
             // Fill default values
-            this.SetMultipart(this.request.Headers.Get(HttpHeaderNames.ContentType));
+            this.SetMultipart(this.request.Headers.Get(HttpHeaderNames.ContentType, null));
             if (request is IHttpContent content)
             {
                 // Offer automatically if the given request is als type of HttpContent

--- a/src/DotNetty.Codecs.Http/Multipart/HttpPostRequestDecoder.cs
+++ b/src/DotNetty.Codecs.Http/Multipart/HttpPostRequestDecoder.cs
@@ -43,9 +43,9 @@ namespace DotNetty.Codecs.Http.Multipart
 
         public static bool IsMultipartRequest(IHttpRequest request)
         {
-            if (request.Headers.Contains(HttpHeaderNames.ContentType))
+            if (request.Headers.TryGet(HttpHeaderNames.ContentType, out ICharSequence contentType))
             {
-                return GetMultipartDataBoundary(request.Headers.Get(HttpHeaderNames.ContentType)) != null;
+                return GetMultipartDataBoundary(contentType) != null;
             }
             else
             {

--- a/src/DotNetty.Codecs/HeadersUtils.cs
+++ b/src/DotNetty.Codecs/HeadersUtils.cs
@@ -27,17 +27,24 @@ namespace DotNetty.Codecs
             return values;
         }
 
-        public static string GetAsString<TKey, TValue>(IHeaders<TKey, TValue> headers, TKey name)
+        public static bool TryGetAsString<TKey, TValue>(IHeaders<TKey, TValue> headers, TKey name, out string value)
             where TKey : class
             where TValue : class
         {
-            TValue orig = headers.Get(name);
-            return orig?.ToString();
+            if (headers.TryGet(name, out TValue orig))
+            {
+                value = orig.ToString();
+                return true;
+            }
+            else
+            {
+                value = default(string);
+                return false;
+            }
         }
 
         public static string ToString<TKey, TValue>(IEnumerable<HeaderEntry<TKey, TValue>> headers, int size)
             where TKey : class
-            where TValue : class
         {
             string simpleName = StringUtil.SimpleClassName(headers);
             if (size == 0)

--- a/src/DotNetty.Codecs/IHeaders.cs
+++ b/src/DotNetty.Codecs/IHeaders.cs
@@ -7,13 +7,12 @@ namespace DotNetty.Codecs
 
     public interface IHeaders<TKey, TValue> : IEnumerable<HeaderEntry<TKey, TValue>> 
         where TKey : class
-        where TValue : class
     {
-        TValue Get(TKey name);
+        bool TryGet(TKey name, out TValue value);
 
         TValue Get(TKey name, TValue defaultValue);
 
-        TValue GetAndRemove(TKey name);
+        bool TryRemove(TKey name, out TValue value);
 
         TValue GetAndRemove(TKey name, TValue defaultValue);
 
@@ -21,75 +20,75 @@ namespace DotNetty.Codecs
 
         IList<TValue> GetAllAndRemove(TKey name);
 
-        bool? GetBoolean(TKey name);
+        bool TryGetBoolean(TKey name, out bool value);
 
         bool GetBoolean(TKey name, bool defaultValue);
 
-        byte? GetByte(TKey name);
+        bool TryGetByte(TKey name, out byte value);
 
         byte GetByte(TKey name, byte defaultValue);
 
-        char? GetChar(TKey name);
+        bool TryGetChar(TKey name, out char value);
 
         char GetChar(TKey name, char defaultValue);
 
-        short? GetShort(TKey name);
+        bool TryGetShort(TKey name, out short value);
 
         short GetShort(TKey name, short defaultValue);
 
-        int? GetInt(TKey name);
+        bool TryGetInt(TKey name, out int value);
 
         int GetInt(TKey name, int defaultValue);
 
-        long? GetLong(TKey name);
+        bool TryGetLong(TKey name, out long value);
 
         long GetLong(TKey name, long defaultValue);
 
-        float? GetFloat(TKey name);
+        bool TryGetFloat(TKey name, out float value);
 
         float GetFloat(TKey name, float defaultValue);
 
-        double? GetDouble(TKey name);
+        bool GetDouble(TKey name, out double value);
 
         double GetDouble(TKey name, double defaultValue);
 
-        long? GetTimeMillis(TKey name);
+        bool TryGetTimeMillis(TKey name, out long value);
 
         long GetTimeMillis(TKey name, long defaultValue);
 
-        bool? GetBooleanAndRemove(TKey name);
+        bool TryGetBooleanAndRemove(TKey name, out bool value);
 
         bool GetBooleanAndRemove(TKey name, bool defaultValue);
 
-        byte? GetByteAndRemove(TKey name);
+        bool TryGetByteAndRemove(TKey name, out byte value);
 
         byte GetByteAndRemove(TKey name, byte defaultValue);
 
-        char? GetCharAndRemove(TKey name);
+        bool TryGetCharAndRemove(TKey name, out char value);
 
         char GetCharAndRemove(TKey name, char defaultValue);
 
-        short? GetShortAndRemove(TKey name);
+        bool TryGetShortAndRemove(TKey name, out short value);
 
         short GetShortAndRemove(TKey name, short defaultValue);
 
-        int? GetIntAndRemove(TKey name);
+        bool TryGetIntAndRemove(TKey name, out int value);
 
         int GetIntAndRemove(TKey name, int defaultValue);
 
-        long? GetLongAndRemove(TKey name);
+        bool TryGetLongAndRemove(TKey name, out long value);
 
         long GetLongAndRemove(TKey name, long defaultValue);
 
-        float? GetFloatAndRemove(TKey name);
+        bool TryGetFloatAndRemove(TKey name, out float value);
 
         float GetFloatAndRemove(TKey name, float defaultValue);
 
-        double? GetDoubleAndRemove(TKey name);
+        bool TryGetDoubleAndRemove(TKey name, out double value);
 
         double GetDoubleAndRemove(TKey name, double defaultValue);
 
-        long? GetTimeMillisAndRemove(TKey name);
+        bool TryGetTimeMillisAndRemove(TKey name, out long value);
 
         long GetTimeMillisAndRemove(TKey name, long defaultValue);
 

--- a/test/DotNetty.Codecs.Http.Tests/CombinedHttpHeadersTest.cs
+++ b/test/DotNetty.Codecs.Http.Tests/CombinedHttpHeadersTest.cs
@@ -40,7 +40,7 @@ namespace DotNetty.Codecs.Http.Tests
             otherHeaders.Add(HeaderName, "a");
             otherHeaders.Add(HeaderName, "b");
             headers.Add(otherHeaders);
-            Assert.Equal("a,b", headers.Get(HeaderName).ToString());
+            Assert.Equal("a,b", headers.Get(HeaderName, null)?.ToString());
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace DotNetty.Codecs.Http.Tests
             otherHeaders.Add(HeaderName, "b");
             otherHeaders.Add(HeaderName, "c");
             headers.Add(otherHeaders);
-            Assert.Equal("a,b,c", headers.Get(HeaderName).ToString());
+            Assert.Equal("a,b,c", headers.Get(HeaderName, null)?.ToString());
         }
 
         [Fact]
@@ -64,7 +64,7 @@ namespace DotNetty.Codecs.Http.Tests
             otherHeaders.Add(HeaderName, "b");
             otherHeaders.Add(HeaderName, "c");
             headers.Set(otherHeaders);
-            Assert.Equal("b,c", headers.Get(HeaderName).ToString());
+            Assert.Equal("b,c", headers.Get(HeaderName, null)?.ToString());
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace DotNetty.Codecs.Http.Tests
             otherHeaders.Add(HeaderName, "b");
             otherHeaders.Add(HeaderName, "c");
             headers.Add(otherHeaders);
-            Assert.Equal("a,b,c", headers.Get(HeaderName).ToString());
+            Assert.Equal("a,b,c", headers.Get(HeaderName, null)?.ToString());
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace DotNetty.Codecs.Http.Tests
             otherHeaders.Add(HeaderName, "b");
             otherHeaders.Add(HeaderName, "c");
             headers.Set(otherHeaders);
-            Assert.Equal("b,c", headers.Get(HeaderName).ToString());
+            Assert.Equal("b,c", headers.Get(HeaderName, null)?.ToString());
         }
 
         [Fact]
@@ -96,7 +96,7 @@ namespace DotNetty.Codecs.Http.Tests
         {
             CombinedHttpHeaders headers = NewCombinedHttpHeaders();
             headers.Add(HeaderName, HeaderValue.SixQuoted.Subset(4));
-            Assert.True(ContentEquals((StringCharSequence)HeaderValue.SixQuoted.SubsetAsCsvString(4), headers.Get(HeaderName)));
+            Assert.True(ContentEquals((StringCharSequence)HeaderValue.SixQuoted.SubsetAsCsvString(4), headers.Get(HeaderName, null)));
             Assert.Equal(HeaderValue.SixQuoted.Subset(4), headers.GetAll(HeaderName));
         }
 
@@ -105,7 +105,7 @@ namespace DotNetty.Codecs.Http.Tests
         {
             CombinedHttpHeaders headers = NewCombinedHttpHeaders();
             headers.Add(HeaderName, HeaderValue.Eight.Subset(6));
-            Assert.True(ContentEquals((StringCharSequence)HeaderValue.Eight.SubsetAsCsvString(6), headers.Get(HeaderName)));
+            Assert.True(ContentEquals((StringCharSequence)HeaderValue.Eight.SubsetAsCsvString(6), headers.Get(HeaderName, null)));
             Assert.Equal(HeaderValue.Eight.Subset(6), headers.GetAll(HeaderName));
         }
 
@@ -117,7 +117,7 @@ namespace DotNetty.Codecs.Http.Tests
             {
                 headers.Add(HeaderName, "value");
             }
-            Assert.True(ContentEquals((StringCharSequence)"value,value,value,value,value", headers.Get(HeaderName)));
+            Assert.True(ContentEquals((StringCharSequence)"value,value,value,value,value", headers.Get(HeaderName, null)));
         }
 
         [Fact]
@@ -240,7 +240,7 @@ namespace DotNetty.Codecs.Http.Tests
 
         static void AssertCsvValues(CombinedHttpHeaders headers, HeaderValue headerValue)
         {
-            Assert.True(ContentEquals(headerValue.AsCsv(), headers.Get(HeaderName)));
+            Assert.True(ContentEquals(headerValue.AsCsv(), headers.Get(HeaderName, null)));
 
             List<ICharSequence> expected = headerValue.AsList();
             IList<ICharSequence> values = headers.GetAll(HeaderName);
@@ -254,7 +254,7 @@ namespace DotNetty.Codecs.Http.Tests
 
         static void AssertCsvValue(CombinedHttpHeaders headers, HeaderValue headerValue)
         {
-            Assert.True(ContentEquals((StringCharSequence)headerValue.ToString(), headers.Get(HeaderName)));
+            Assert.True(ContentEquals((StringCharSequence)headerValue.ToString(), headers.Get(HeaderName, null)));
             Assert.True(ContentEquals((StringCharSequence)headerValue.ToString(), headers.GetAll(HeaderName)[0]));
         }
 
@@ -318,7 +318,7 @@ namespace DotNetty.Codecs.Http.Tests
             var expected = new List<ICharSequence> { (StringCharSequence)"a", (StringCharSequence)"", (StringCharSequence)"b", (StringCharSequence)"", (StringCharSequence)"c, d" };
             IList<ICharSequence> actual = headers.GetAll(HeaderName);
             Assert.True(expected.SequenceEqual(actual));
-            Assert.Equal("a,,b,,\"c, d\"", headers.Get(HeaderName).ToString());
+            Assert.Equal("a,,b,,\"c, d\"", headers.Get(HeaderName, null)?.ToString());
 
             Assert.True(headers.ContainsValue(HeaderName, (StringCharSequence)"a", true));
             Assert.True(headers.ContainsValue(HeaderName, (StringCharSequence)" a ", true));

--- a/test/DotNetty.Codecs.Http.Tests/Cors/CorsConfigTest.cs
+++ b/test/DotNetty.Codecs.Http.Tests/Cors/CorsConfigTest.cs
@@ -100,7 +100,7 @@ namespace DotNetty.Codecs.Http.Tests.Cors
         {
             CorsConfig cors = CorsConfigBuilder.ForAnyOrigin()
                 .PreflightResponseHeader((AsciiString)"SingleValue", (StringCharSequence)"value").Build();
-            Assert.Equal((AsciiString)"value", cors.PreflightResponseHeaders().Get((AsciiString)"SingleValue"));
+            Assert.Equal((AsciiString)"value", cors.PreflightResponseHeaders().Get((AsciiString)"SingleValue", null));
         }
 
         [Fact]
@@ -118,8 +118,8 @@ namespace DotNetty.Codecs.Http.Tests.Cors
         public void DefaultPreflightResponseHeaders()
         {
             CorsConfig cors = CorsConfigBuilder.ForAnyOrigin().Build();
-            Assert.NotNull(cors.PreflightResponseHeaders().Get(HttpHeaderNames.Date));
-            Assert.Equal("0", cors.PreflightResponseHeaders().Get(HttpHeaderNames.ContentLength));
+            Assert.NotNull(cors.PreflightResponseHeaders().Get(HttpHeaderNames.Date, null));
+            Assert.Equal("0", cors.PreflightResponseHeaders().Get(HttpHeaderNames.ContentLength, null));
         }
 
         [Fact]

--- a/test/DotNetty.Codecs.Http.Tests/Cors/CorsHandlerTest.cs
+++ b/test/DotNetty.Codecs.Http.Tests/Cors/CorsHandlerTest.cs
@@ -24,8 +24,8 @@ namespace DotNetty.Codecs.Http.Tests.Cors
         public void SimpleRequestWithAnyOrigin()
         {
             IHttpResponse response = SimpleRequest(CorsConfigBuilder.ForAnyOrigin().Build(), "http://localhost:7777");
-            Assert.Equal("*", response.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin).ToString());
-            Assert.Null(response.Headers.Get(HttpHeaderNames.AccessControlAllowHeaders));
+            Assert.Equal("*", response.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin, null).ToString());
+            Assert.Null(response.Headers.Get(HttpHeaderNames.AccessControlAllowHeaders, null));
         }
 
         [Fact]
@@ -35,9 +35,9 @@ namespace DotNetty.Codecs.Http.Tests.Cors
                 .AllowNullOrigin()
                 .AllowCredentials()
                 .Build(), "null");
-            Assert.Equal("null", response.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin).ToString());
-            Assert.Equal("true", response.Headers.Get(HttpHeaderNames.AccessControlAllowCredentials).ToString());
-            Assert.Null(response.Headers.Get(HttpHeaderNames.AccessControlAllowHeaders));
+            Assert.Equal("null", response.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin, null).ToString());
+            Assert.Equal("true", response.Headers.Get(HttpHeaderNames.AccessControlAllowCredentials, null).ToString());
+            Assert.Null(response.Headers.Get(HttpHeaderNames.AccessControlAllowHeaders, null));
         }
 
         [Fact]
@@ -45,8 +45,8 @@ namespace DotNetty.Codecs.Http.Tests.Cors
         {
             var origin = new AsciiString("http://localhost:8888");
             IHttpResponse response = SimpleRequest(CorsConfigBuilder.ForOrigin(origin).Build(), origin.ToString());
-            Assert.Equal(origin, response.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin));
-            Assert.Null(response.Headers.Get(HttpHeaderNames.AccessControlAllowHeaders));
+            Assert.Equal(origin, response.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin, null));
+            Assert.Null(response.Headers.Get(HttpHeaderNames.AccessControlAllowHeaders, null));
         }
 
         [Fact]
@@ -56,11 +56,11 @@ namespace DotNetty.Codecs.Http.Tests.Cors
             var origin2 = new AsciiString("https://localhost:8888");
             ICharSequence[] origins = { origin1, origin2};
             IHttpResponse response1 = SimpleRequest(CorsConfigBuilder.ForOrigins(origins).Build(), origin1.ToString());
-            Assert.Equal(origin1, response1.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin));
-            Assert.Null(response1.Headers.Get(HttpHeaderNames.AccessControlAllowHeaders));
+            Assert.Equal(origin1, response1.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin, null));
+            Assert.Null(response1.Headers.Get(HttpHeaderNames.AccessControlAllowHeaders, null));
             IHttpResponse response2 = SimpleRequest(CorsConfigBuilder.ForOrigins(origins).Build(), origin2.ToString());
-            Assert.Equal(origin2, response2.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin));
-            Assert.Null(response2.Headers.Get(HttpHeaderNames.AccessControlAllowHeaders));
+            Assert.Equal(origin2, response2.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin, null));
+            Assert.Null(response2.Headers.Get(HttpHeaderNames.AccessControlAllowHeaders, null));
         }
 
         [Fact]
@@ -69,8 +69,8 @@ namespace DotNetty.Codecs.Http.Tests.Cors
             var origin = new AsciiString("http://localhost:8888");
             IHttpResponse response = SimpleRequest(CorsConfigBuilder.ForOrigins(
                 new AsciiString("https://localhost:8888")).Build(), origin.ToString());
-            Assert.Null(response.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin));
-            Assert.Null(response.Headers.Get(HttpHeaderNames.AccessControlAllowHeaders));
+            Assert.Null(response.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin, null));
+            Assert.Null(response.Headers.Get(HttpHeaderNames.AccessControlAllowHeaders, null));
         }
 
         [Fact]
@@ -79,10 +79,10 @@ namespace DotNetty.Codecs.Http.Tests.Cors
             CorsConfig config = CorsConfigBuilder.ForOrigin(
                 new AsciiString("http://localhost:8888")).AllowedRequestMethods(HttpMethod.Get, HttpMethod.Delete).Build();
             IHttpResponse response = PreflightRequest(config, "http://localhost:8888", "content-type, xheader1");
-            Assert.Equal("http://localhost:8888", response.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin));
-            Assert.Contains("GET", response.Headers.Get(HttpHeaderNames.AccessControlAllowMethods).ToString());
-            Assert.Contains("DELETE", response.Headers.Get(HttpHeaderNames.AccessControlAllowMethods).ToString());
-            Assert.Equal(HttpHeaderNames.Origin.ToString(), response.Headers.Get(HttpHeaderNames.Vary));
+            Assert.Equal("http://localhost:8888", response.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin, null));
+            Assert.Contains("GET", response.Headers.Get(HttpHeaderNames.AccessControlAllowMethods, null).ToString());
+            Assert.Contains("DELETE", response.Headers.Get(HttpHeaderNames.AccessControlAllowMethods, null).ToString());
+            Assert.Equal(HttpHeaderNames.Origin.ToString(), response.Headers.Get(HttpHeaderNames.Vary, null));
         }
 
         [Fact]
@@ -95,8 +95,8 @@ namespace DotNetty.Codecs.Http.Tests.Cors
                 .PreflightResponseHeader((AsciiString)HeaderName, (AsciiString)Value1, (AsciiString)Value2).Build();
             IHttpResponse response = PreflightRequest(config, "http://localhost:8888", "content-type, xheader1");
             AssertValues(response, HeaderName, Value1, Value2);
-            Assert.Equal(HttpHeaderNames.Origin.ToString(), response.Headers.Get(HttpHeaderNames.Vary));
-            Assert.Equal("0", response.Headers.Get(HttpHeaderNames.ContentLength).ToString());
+            Assert.Equal(HttpHeaderNames.Origin.ToString(), response.Headers.Get(HttpHeaderNames.Vary, null));
+            Assert.Equal("0", response.Headers.Get(HttpHeaderNames.ContentLength, null).ToString());
         }
 
         [Fact]
@@ -110,7 +110,7 @@ namespace DotNetty.Codecs.Http.Tests.Cors
                 .Build();
             IHttpResponse response = PreflightRequest(config, "http://localhost:8888", "content-type, xheader1");
             AssertValues(response, HeaderName, Value1, Value2);
-            Assert.Equal(HttpHeaderNames.Origin.ToString(), response.Headers.Get(HttpHeaderNames.Vary));
+            Assert.Equal(HttpHeaderNames.Origin.ToString(), response.Headers.Get(HttpHeaderNames.Vary, null));
         }
 
         class ValueGenerator : ICallable<object>
@@ -124,8 +124,8 @@ namespace DotNetty.Codecs.Http.Tests.Cors
             CorsConfig config = CorsConfigBuilder.ForOrigin((AsciiString)"http://localhost:8888")
                 .PreflightResponseHeader((AsciiString)"GenHeader", new ValueGenerator()).Build();
             IHttpResponse response = PreflightRequest(config, "http://localhost:8888", "content-type, xheader1");
-            Assert.Equal("generatedValue", response.Headers.Get((AsciiString)"GenHeader").ToString());
-            Assert.Equal(HttpHeaderNames.Origin.ToString(), response.Headers.Get(HttpHeaderNames.Vary));
+            Assert.Equal("generatedValue", response.Headers.Get((AsciiString)"GenHeader", null).ToString());
+            Assert.Equal(HttpHeaderNames.Origin.ToString(), response.Headers.Get(HttpHeaderNames.Vary, null));
         }
 
         [Fact]
@@ -137,8 +137,8 @@ namespace DotNetty.Codecs.Http.Tests.Cors
                     .AllowCredentials()
                     .Build();
             IHttpResponse response = PreflightRequest(config, origin.ToString(), "content-type, xheader1");
-            Assert.Equal("null", response.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin));
-            Assert.Equal("true", response.Headers.Get(HttpHeaderNames.AccessControlAllowCredentials));
+            Assert.Equal("null", response.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin, null));
+            Assert.Equal("true", response.Headers.Get(HttpHeaderNames.AccessControlAllowCredentials, null));
         }
 
         [Fact]
@@ -147,7 +147,7 @@ namespace DotNetty.Codecs.Http.Tests.Cors
             var origin = new AsciiString("null");
             CorsConfig config = CorsConfigBuilder.ForOrigin(origin).AllowCredentials().Build();
             IHttpResponse response = PreflightRequest(config, origin.ToString(), "content-type, xheader1");
-            Assert.Equal("true", response.Headers.Get(HttpHeaderNames.AccessControlAllowCredentials));
+            Assert.Equal("true", response.Headers.Get(HttpHeaderNames.AccessControlAllowCredentials, null));
         }
 
         [Fact]
@@ -165,9 +165,9 @@ namespace DotNetty.Codecs.Http.Tests.Cors
             CorsConfig config = CorsConfigBuilder.ForAnyOrigin()
                 .ExposeHeaders((AsciiString)"custom1", (AsciiString)"custom2").Build();
             IHttpResponse response = SimpleRequest(config, "http://localhost:7777");
-            Assert.Equal("*", response.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin));
-            Assert.Contains("custom1", response.Headers.Get(HttpHeaderNames.AccessControlExposeHeaders).ToString());
-            Assert.Contains("custom2", response.Headers.Get(HttpHeaderNames.AccessControlExposeHeaders).ToString());
+            Assert.Equal("*", response.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin, null));
+            Assert.Contains("custom1", response.Headers.Get(HttpHeaderNames.AccessControlExposeHeaders, null).ToString());
+            Assert.Contains("custom2", response.Headers.Get(HttpHeaderNames.AccessControlExposeHeaders, null).ToString());
         }
 
         [Fact]
@@ -175,7 +175,7 @@ namespace DotNetty.Codecs.Http.Tests.Cors
         {
             CorsConfig config = CorsConfigBuilder.ForAnyOrigin().AllowCredentials().Build();
             IHttpResponse response = SimpleRequest(config, "http://localhost:7777");
-            Assert.Equal("true", response.Headers.Get(HttpHeaderNames.AccessControlAllowCredentials));
+            Assert.Equal("true", response.Headers.Get(HttpHeaderNames.AccessControlAllowCredentials, null));
         }
 
         [Fact]
@@ -191,9 +191,9 @@ namespace DotNetty.Codecs.Http.Tests.Cors
         {
             CorsConfig config = CorsConfigBuilder.ForAnyOrigin().AllowCredentials().Build();
             IHttpResponse response = SimpleRequest(config, "http://localhost:7777");
-            Assert.Equal("true", response.Headers.Get(HttpHeaderNames.AccessControlAllowCredentials));
-            Assert.Equal("http://localhost:7777", response.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin).ToString());
-            Assert.Equal(HttpHeaderNames.Origin.ToString(), response.Headers.Get(HttpHeaderNames.Vary));
+            Assert.Equal("true", response.Headers.Get(HttpHeaderNames.AccessControlAllowCredentials, null));
+            Assert.Equal("http://localhost:7777", response.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin, null).ToString());
+            Assert.Equal(HttpHeaderNames.Origin.ToString(), response.Headers.Get(HttpHeaderNames.Vary, null));
         }
 
         [Fact]
@@ -202,8 +202,8 @@ namespace DotNetty.Codecs.Http.Tests.Cors
             CorsConfig config = CorsConfigBuilder.ForAnyOrigin()
                 .ExposeHeaders((AsciiString)"one", (AsciiString)"two").Build();
             IHttpResponse response = SimpleRequest(config, "http://localhost:7777");
-            Assert.Contains("one", response.Headers.Get(HttpHeaderNames.AccessControlExposeHeaders).ToString());
-            Assert.Contains("two", response.Headers.Get(HttpHeaderNames.AccessControlExposeHeaders).ToString());
+            Assert.Contains("one", response.Headers.Get(HttpHeaderNames.AccessControlExposeHeaders, null).ToString());
+            Assert.Contains("two", response.Headers.Get(HttpHeaderNames.AccessControlExposeHeaders, null).ToString());
         }
 
         [Fact]
@@ -213,7 +213,7 @@ namespace DotNetty.Codecs.Http.Tests.Cors
                 .ShortCircuit().Build();
             IHttpResponse response = SimpleRequest(config, "http://localhost:7777");
             Assert.Equal(HttpResponseStatus.Forbidden, response.Status);
-            Assert.Equal("0", response.Headers.Get(HttpHeaderNames.ContentLength).ToString());
+            Assert.Equal("0", response.Headers.Get(HttpHeaderNames.ContentLength, null).ToString());
         }
 
         [Fact]
@@ -222,7 +222,7 @@ namespace DotNetty.Codecs.Http.Tests.Cors
             CorsConfig config = CorsConfigBuilder.ForOrigin((AsciiString)"http://localhost:8080").Build();
             IHttpResponse response = SimpleRequest(config, "http://localhost:7777");
             Assert.Equal(HttpResponseStatus.OK, response.Status);
-            Assert.Null(response.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin));
+            Assert.Null(response.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin, null));
         }
 
         [Fact]
@@ -232,7 +232,7 @@ namespace DotNetty.Codecs.Http.Tests.Cors
                 .ShortCircuit().Build();
             IHttpResponse response = SimpleRequest(config, null);
             Assert.Equal(HttpResponseStatus.OK, response.Status);
-            Assert.Null(response.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin));
+            Assert.Null(response.Headers.Get(HttpHeaderNames.AccessControlAllowOrigin, null));
         }
 
         [Fact]
@@ -422,7 +422,7 @@ namespace DotNetty.Codecs.Http.Tests.Cors
 
         static void AssertValues(IHttpResponse response, string headerName, params string[] values)
         {
-            ICharSequence header = response.Headers.Get(new AsciiString(headerName));
+            ICharSequence header = response.Headers.Get(new AsciiString(headerName), null);
             foreach (string value in values)
             {
                 Assert.Contains(value, header.ToString());

--- a/test/DotNetty.Codecs.Http.Tests/DefaultHttpHeadersTest.cs
+++ b/test/DotNetty.Codecs.Http.Tests/DefaultHttpHeadersTest.cs
@@ -59,12 +59,12 @@ namespace DotNetty.Codecs.Http.Tests
             headers.Add(HttpHeadersTestUtils.Of("Connection"), Connection);
 
             // Passes
-            string value = headers.GetAsString(HttpHeaderNames.Connection);
+            headers.TryGetAsString(HttpHeaderNames.Connection, out string value);
             Assert.NotNull(value);
             Assert.Equal(Connection, value);
 
             // Passes
-            ICharSequence value2 = headers.Get(HttpHeaderNames.Connection);
+            ICharSequence value2 = headers.Get(HttpHeaderNames.Connection, null);
             Assert.NotNull(value2);
             Assert.Equal(Connection, value2);
         }
@@ -78,11 +78,11 @@ namespace DotNetty.Codecs.Http.Tests
             const string CacheControl = "no-cache";
             headers.Add(HttpHeaderNames.CacheControl, CacheControl);
 
-            string value = headers.GetAsString(HttpHeaderNames.CacheControl);
+            headers.TryGetAsString(HttpHeaderNames.CacheControl, out string value);
             Assert.NotNull(value);
             Assert.Equal(CacheControl, value);
 
-            ICharSequence value2 = headers.Get(HttpHeaderNames.CacheControl);
+            ICharSequence value2 = headers.Get(HttpHeaderNames.CacheControl, null);
             Assert.NotNull(value2);
             Assert.Equal(CacheControl, value2);
         }
@@ -94,7 +94,7 @@ namespace DotNetty.Codecs.Http.Tests
             headers.Add(HttpHeadersTestUtils.Of("Foo"), HttpHeadersTestUtils.Of("1"));
             headers.Add(HttpHeadersTestUtils.Of("Foo"), HttpHeadersTestUtils.Of("2"));
 
-            Assert.Equal("1", headers.Get(HttpHeadersTestUtils.Of("Foo")));
+            Assert.Equal("1", headers.Get(HttpHeadersTestUtils.Of("Foo"), null));
 
             IList<ICharSequence> values = headers.GetAll(HttpHeadersTestUtils.Of("Foo"));
             Assert.Equal(2, values.Count);
@@ -137,7 +137,7 @@ namespace DotNetty.Codecs.Http.Tests
 
         static void AssertDefaultValues(HttpHeaders headers, HttpHeadersTestUtils.HeaderValue headerValue)
         {
-            Assert.True(AsciiString.ContentEquals(headerValue.AsList()[0], (StringCharSequence)headers.Get(HeaderName)));
+            Assert.True(AsciiString.ContentEquals(headerValue.AsList()[0], (StringCharSequence)headers.Get(HeaderName, null)));
             List<ICharSequence> expected = headerValue.AsList();
             IList<ICharSequence> actual = headers.GetAll(HeaderName);
             Assert.Equal(expected.Count, actual.Count);

--- a/test/DotNetty.Codecs.Http.Tests/DefaultHttpRequestTest.cs
+++ b/test/DotNetty.Codecs.Http.Tests/DefaultHttpRequestTest.cs
@@ -29,7 +29,7 @@ namespace DotNetty.Codecs.Http.Tests
             // Check if random access returns nothing.
             for (int i = 0; i < 1000; i++)
             {
-                Assert.Null(h.Get(HttpHeadersTestUtils.Of(i.ToString())));
+                Assert.False(h.TryGet(HttpHeadersTestUtils.Of(i.ToString()), out _));
             }
 
             // Check if sequential access returns nothing.

--- a/test/DotNetty.Codecs.Http.Tests/HttpContentCompressorTest.cs
+++ b/test/DotNetty.Codecs.Http.Tests/HttpContentCompressorTest.cs
@@ -171,7 +171,7 @@ namespace DotNetty.Codecs.Http.Tests
 
             var lastChunk = ch.ReadOutbound<ILastHttpContent>();
             Assert.NotNull(lastChunk);
-            Assert.Equal("Netty", lastChunk.TrailingHeaders.Get((AsciiString)"X-Test").ToString());
+            Assert.Equal("Netty", lastChunk.TrailingHeaders.Get((AsciiString)"X-Test", null).ToString());
             lastChunk.Release();
 
             var last = ch.ReadOutbound<object>();
@@ -195,8 +195,8 @@ namespace DotNetty.Codecs.Http.Tests
             Assert.NotNull(res);
             Assert.False(res is IHttpContent, $"{res.GetType()}");
 
-            Assert.Null(res.Headers.Get(HttpHeaderNames.TransferEncoding));
-            Assert.Equal("gzip", res.Headers.Get(HttpHeaderNames.ContentEncoding).ToString());
+            Assert.False(res.Headers.TryGet(HttpHeaderNames.TransferEncoding, out _));
+            Assert.Equal("gzip", res.Headers.Get(HttpHeaderNames.ContentEncoding, null).ToString());
 
             long contentLengthHeaderValue = HttpUtil.GetContentLength(res);
             long observedLength = 0;
@@ -283,10 +283,10 @@ namespace DotNetty.Codecs.Http.Tests
             res = ch.ReadOutbound<IFullHttpResponse>();
             Assert.NotNull(res);
 
-            Assert.Null(res.Headers.Get(HttpHeaderNames.TransferEncoding));
+            Assert.False(res.Headers.TryGet(HttpHeaderNames.TransferEncoding, out _));
 
             // Content encoding shouldn't be modified.
-            Assert.Null(res.Headers.Get(HttpHeaderNames.ContentEncoding));
+            Assert.False(res.Headers.TryGet(HttpHeaderNames.ContentEncoding, out _));
             Assert.Equal(0, res.Content.ReadableBytes);
             Assert.Equal("", res.Content.ToString(Encoding.ASCII));
             res.Release();
@@ -306,13 +306,13 @@ namespace DotNetty.Codecs.Http.Tests
             ch.WriteOutbound(res);
 
             res = ch.ReadOutbound<IFullHttpResponse>();
-            Assert.Null(res.Headers.Get(HttpHeaderNames.TransferEncoding));
+            Assert.False(res.Headers.TryGet(HttpHeaderNames.TransferEncoding, out _));
 
             // Content encoding shouldn't be modified.
-            Assert.Null(res.Headers.Get(HttpHeaderNames.ContentEncoding));
+            Assert.False(res.Headers.TryGet(HttpHeaderNames.ContentEncoding, out _));
             Assert.Equal(0, res.Content.ReadableBytes);
             Assert.Equal("", res.Content.ToString(Encoding.ASCII));
-            Assert.Equal("Netty", res.TrailingHeaders.Get((AsciiString)"X-Test"));
+            Assert.Equal("Netty", res.TrailingHeaders.Get((AsciiString)"X-Test", null));
 
             var last = ch.ReadOutbound<object>();
             Assert.Null(last);
@@ -341,13 +341,13 @@ namespace DotNetty.Codecs.Http.Tests
 
             res = ch.ReadOutbound<IFullHttpResponse>();
             Assert.NotNull(res);
-            Assert.Null(res.Headers.Get(HttpHeaderNames.TransferEncoding));
+            Assert.False(res.Headers.TryGet(HttpHeaderNames.TransferEncoding, out _));
 
             // Content encoding shouldn't be modified.
-            Assert.Null(res.Headers.Get(HttpHeaderNames.ContentEncoding));
+            Assert.False(res.Headers.TryGet(HttpHeaderNames.ContentEncoding, out _));
             Assert.Equal(0, res.Content.ReadableBytes);
             Assert.Equal("", res.Content.ToString(Encoding.ASCII));
-            Assert.Equal("Netty", res.TrailingHeaders.Get((AsciiString)"X-Test"));
+            Assert.Equal("Netty", res.TrailingHeaders.Get((AsciiString)"X-Test", null));
 
             var last = ch.ReadOutbound<object>();
             Assert.Null(last);
@@ -410,8 +410,8 @@ namespace DotNetty.Codecs.Http.Tests
             Assert.True(ch.WriteOutbound(res));
 
             var response = ch.ReadOutbound<IFullHttpResponse>();
-            Assert.Equal(len.ToString(), response.Headers.Get(HttpHeaderNames.ContentLength).ToString());
-            Assert.Equal(HttpHeaderValues.Identity.ToString(), response.Headers.Get(HttpHeaderNames.ContentEncoding).ToString());
+            Assert.Equal(len.ToString(), response.Headers.Get(HttpHeaderNames.ContentLength, null).ToString());
+            Assert.Equal(HttpHeaderValues.Identity.ToString(), response.Headers.Get(HttpHeaderNames.ContentEncoding, null).ToString());
             Assert.Equal("Hello, World", response.Content.ToString(Encoding.ASCII));
             response.Release();
 
@@ -433,9 +433,9 @@ namespace DotNetty.Codecs.Http.Tests
             var content = res as IHttpContent;
             Assert.Null(content);
 
-            Assert.Equal("chunked", res.Headers.Get(HttpHeaderNames.TransferEncoding));
-            Assert.Null(res.Headers.Get(HttpHeaderNames.ContentLength));
-            Assert.Equal("gzip", res.Headers.Get(HttpHeaderNames.ContentEncoding));
+            Assert.Equal("chunked", res.Headers.Get(HttpHeaderNames.TransferEncoding, null));
+            Assert.False(res.Headers.TryGet(HttpHeaderNames.ContentLength, out _));
+            Assert.Equal("gzip", res.Headers.Get(HttpHeaderNames.ContentEncoding, null));
         }
     }
 }

--- a/test/DotNetty.Codecs.Http.Tests/HttpContentDecoderTest.cs
+++ b/test/DotNetty.Codecs.Http.Tests/HttpContentDecoderTest.cs
@@ -57,9 +57,8 @@ namespace DotNetty.Codecs.Http.Tests
 
             var req = channel.ReadInbound<IFullHttpRequest>();
             Assert.NotNull(req);
-            int? length = req.Headers.GetInt(HttpHeaderNames.ContentLength);
-            Assert.True(length.HasValue);
-            Assert.Equal(HelloWorld.Length, length.Value);
+            Assert.True(req.Headers.TryGetInt(HttpHeaderNames.ContentLength, out int length));
+            Assert.Equal(HelloWorld.Length, length);
             Assert.Equal(HelloWorld, req.Content.ToString(Encoding.ASCII));
             req.Release();
 
@@ -86,9 +85,8 @@ namespace DotNetty.Codecs.Http.Tests
 
             var resp = channel.ReadInbound<IFullHttpResponse>();
             Assert.NotNull(resp);
-            int? length = resp.Headers.GetInt(HttpHeaderNames.ContentLength);
-            Assert.True(length.HasValue);
-            Assert.Equal(HelloWorld.Length, length.Value);
+            Assert.True(resp.Headers.TryGetInt(HttpHeaderNames.ContentLength, out int length));
+            Assert.Equal(HelloWorld.Length, length);
             Assert.Equal(HelloWorld, resp.Content.ToString(Encoding.ASCII));
             resp.Release();
 
@@ -293,8 +291,7 @@ namespace DotNetty.Codecs.Http.Tests
             object o = req.Peek();
             Assert.IsAssignableFrom<IHttpRequest>(o);
             var request = (IHttpRequest)o;
-            ICharSequence v = request.Headers.Get(HttpHeaderNames.ContentLength);
-            if (v != null)
+            if (request.Headers.TryGet(HttpHeaderNames.ContentLength, out ICharSequence v))
             {
                 Assert.Equal(HelloWorld.Length, long.Parse(v.ToString()));
             }
@@ -323,8 +320,7 @@ namespace DotNetty.Codecs.Http.Tests
 
             var req = channel.ReadInbound<IFullHttpRequest>();
             Assert.NotNull(req);
-            ICharSequence value = req.Headers.Get(HttpHeaderNames.ContentLength);
-            Assert.NotNull(value);
+            Assert.True(req.Headers.TryGet(HttpHeaderNames.ContentLength, out ICharSequence value));
             Assert.Equal(HelloWorld.Length, long.Parse(value.ToString()));
             req.Release();
 
@@ -357,7 +353,7 @@ namespace DotNetty.Codecs.Http.Tests
             var r = (IHttpResponse)o;
 
             Assert.False(r.Headers.Contains(HttpHeaderNames.ContentLength));
-            ICharSequence transferEncoding = r.Headers.Get(HttpHeaderNames.TransferEncoding);
+            Assert.True(r.Headers.TryGet(HttpHeaderNames.TransferEncoding, out ICharSequence transferEncoding));
             Assert.NotNull(transferEncoding);
             Assert.Equal(HttpHeaderValues.Chunked, transferEncoding);
 
@@ -385,8 +381,7 @@ namespace DotNetty.Codecs.Http.Tests
 
             var res = channel.ReadInbound<IFullHttpResponse>();
             Assert.NotNull(res);
-            ICharSequence value = res.Headers.Get(HttpHeaderNames.ContentLength);
-            Assert.NotNull(value);
+            Assert.True(res.Headers.TryGet(HttpHeaderNames.ContentLength, out ICharSequence value));
             Assert.Equal(HelloWorld.Length, long.Parse(value.ToString()));
             res.Release();
 

--- a/test/DotNetty.Codecs.Http.Tests/HttpContentEncoderTest.cs
+++ b/test/DotNetty.Codecs.Http.Tests/HttpContentEncoderTest.cs
@@ -133,7 +133,7 @@ namespace DotNetty.Codecs.Http.Tests
             var last = ch.ReadOutbound<ILastHttpContent>();
             Assert.NotNull(last);
             Assert.False(last.Content.IsReadable());
-            Assert.Equal("Netty", last.TrailingHeaders.Get((AsciiString)"X-Test").ToString());
+            Assert.Equal("Netty", last.TrailingHeaders.Get((AsciiString)"X-Test", null).ToString());
             last.Release();
 
             var next = ch.ReadOutbound<object>();
@@ -154,9 +154,9 @@ namespace DotNetty.Codecs.Http.Tests
             var res = ch.ReadOutbound<IHttpResponse>();
             Assert.NotNull(res);
             Assert.False(res is IHttpContent, $"{res.GetType()}");
-            Assert.Null(res.Headers.Get(HttpHeaderNames.TransferEncoding));
-            Assert.Equal("2", res.Headers.Get(HttpHeaderNames.ContentLength).ToString());
-            Assert.Equal("test", res.Headers.Get(HttpHeaderNames.ContentEncoding).ToString());
+            Assert.False(res.Headers.TryGet(HttpHeaderNames.TransferEncoding, out _));
+            Assert.Equal("2", res.Headers.Get(HttpHeaderNames.ContentLength, null).ToString());
+            Assert.Equal("test", res.Headers.Get(HttpHeaderNames.ContentEncoding, null).ToString());
 
             var c = ch.ReadOutbound<IHttpContent>();
             Assert.Equal(2, c.Content.ReadableBytes);
@@ -236,10 +236,10 @@ namespace DotNetty.Codecs.Http.Tests
 
             res = ch.ReadOutbound<IFullHttpResponse>();
             Assert.NotNull(res);
-            Assert.Null(res.Headers.Get(HttpHeaderNames.TransferEncoding));
+            Assert.False(res.Headers.TryGet(HttpHeaderNames.TransferEncoding, out _));
 
             // Content encoding shouldn't be modified.
-            Assert.Null(res.Headers.Get(HttpHeaderNames.ContentEncoding));
+            Assert.False(res.Headers.TryGet(HttpHeaderNames.ContentEncoding, out _));
             Assert.Equal(0, res.Content.ReadableBytes);
             Assert.Equal("", res.Content.ToString(Encoding.ASCII));
             res.Release();
@@ -261,13 +261,13 @@ namespace DotNetty.Codecs.Http.Tests
 
             res = ch.ReadOutbound<IFullHttpResponse>();
             Assert.NotNull(res);
-            Assert.Null(res.Headers.Get(HttpHeaderNames.TransferEncoding));
+            Assert.False(res.Headers.TryGet(HttpHeaderNames.TransferEncoding, out _));
 
             // Content encoding shouldn't be modified.
-            Assert.Null(res.Headers.Get(HttpHeaderNames.ContentEncoding));
+            Assert.False(res.Headers.TryGet(HttpHeaderNames.ContentEncoding, out _));
             Assert.Equal(0, res.Content.ReadableBytes);
             Assert.Equal("", res.Content.ToString(Encoding.ASCII));
-            Assert.Equal("Netty", res.TrailingHeaders.Get((AsciiString)"X-Test"));
+            Assert.Equal("Netty", res.TrailingHeaders.Get((AsciiString)"X-Test", null));
 
             var next = ch.ReadOutbound<object>();
             Assert.Null(next);
@@ -432,8 +432,8 @@ namespace DotNetty.Codecs.Http.Tests
             var res = ch.ReadOutbound<IHttpResponse>();
             Assert.NotNull(res);
             Assert.False(res is IHttpContent);
-            Assert.Equal("chunked", res.Headers.Get(HttpHeaderNames.TransferEncoding).ToString());
-            Assert.Null(res.Headers.Get(HttpHeaderNames.ContentLength));
+            Assert.Equal("chunked", res.Headers.Get(HttpHeaderNames.TransferEncoding, null).ToString());
+            Assert.False(res.Headers.TryGet(HttpHeaderNames.ContentLength, out _));
 
             var chunk = ch.ReadOutbound<ILastHttpContent>();
             Assert.NotNull(chunk);
@@ -449,9 +449,9 @@ namespace DotNetty.Codecs.Http.Tests
             Assert.NotNull(res);
 
             Assert.False(res is IHttpContent, $"{res.GetType()}");
-            Assert.Equal("chunked", res.Headers.Get(HttpHeaderNames.TransferEncoding).ToString());
-            Assert.Null(res.Headers.Get(HttpHeaderNames.ContentLength));
-            Assert.Equal("test", res.Headers.Get(HttpHeaderNames.ContentEncoding).ToString());
+            Assert.Equal("chunked", res.Headers.Get(HttpHeaderNames.TransferEncoding, null).ToString());
+            Assert.False(res.Headers.TryGet(HttpHeaderNames.ContentLength, out _));
+            Assert.Equal("test", res.Headers.Get(HttpHeaderNames.ContentEncoding, null).ToString());
         }
     }
 }

--- a/test/DotNetty.Codecs.Http.Tests/HttpHeadersTest.cs
+++ b/test/DotNetty.Codecs.Http.Tests/HttpHeadersTest.cs
@@ -28,7 +28,7 @@ namespace DotNetty.Codecs.Http.Tests
             headers.Add(HttpHeadersTestUtils.Of("Foo"), HttpHeadersTestUtils.Of("1"));
             headers.Add(HttpHeadersTestUtils.Of("Foo"), HttpHeadersTestUtils.Of("2"));
 
-            Assert.Equal("1", headers.Get(HttpHeadersTestUtils.Of("Foo")));
+            Assert.Equal("1", headers.Get(HttpHeadersTestUtils.Of("Foo"), null));
 
             IList<ICharSequence> values = headers.GetAll(HttpHeadersTestUtils.Of("Foo"));
             Assert.Equal(2, values.Count);

--- a/test/DotNetty.Codecs.Http.Tests/HttpInvalidMessageTest.cs
+++ b/test/DotNetty.Codecs.Http.Tests/HttpInvalidMessageTest.cs
@@ -40,7 +40,7 @@ namespace DotNetty.Codecs.Http.Tests
             Assert.NotNull(dr);
             Assert.False(dr.IsSuccess);
             Assert.True(dr.IsFailure);
-            Assert.Equal("Good Value", req.Headers.Get((AsciiString)"Good_Name").ToString());
+            Assert.Equal("Good Value", req.Headers.Get((AsciiString)"Good_Name", null).ToString());
             Assert.Equal("/maybe-something", req.Uri);
             this.EnsureInboundTrafficDiscarded(ch);
         }
@@ -72,7 +72,7 @@ namespace DotNetty.Codecs.Http.Tests
             Assert.False(dr.IsSuccess);
             Assert.True(dr.IsFailure);
             Assert.Equal("Maybe OK", res.Status.ReasonPhrase);
-            Assert.Equal("Good Value", res.Headers.Get((AsciiString)"Good_Name").ToString());
+            Assert.Equal("Good Value", res.Headers.Get((AsciiString)"Good_Name", null).ToString());
             this.EnsureInboundTrafficDiscarded(ch);
         }
 

--- a/test/DotNetty.Codecs.Http.Tests/HttpObjectAggregatorTest.cs
+++ b/test/DotNetty.Codecs.Http.Tests/HttpObjectAggregatorTest.cs
@@ -37,7 +37,7 @@ namespace DotNetty.Codecs.Http.Tests
             Assert.NotNull(aggregatedMessage);
 
             Assert.Equal(chunk1.Content.ReadableBytes + chunk2.Content.ReadableBytes, HttpUtil.GetContentLength(aggregatedMessage));
-            Assert.Equal(bool.TrueString, aggregatedMessage.Headers.Get((AsciiString)"X-Test").ToString());
+            Assert.Equal(bool.TrueString, aggregatedMessage.Headers.Get((AsciiString)"X-Test", null)?.ToString());
             CheckContentBuffer(aggregatedMessage);
             var last = ch.ReadInbound<object>();
             Assert.Null(last);
@@ -67,8 +67,8 @@ namespace DotNetty.Codecs.Http.Tests
             Assert.NotNull(aggregatedMessage);
 
             Assert.Equal(chunk1.Content.ReadableBytes + chunk2.Content.ReadableBytes, HttpUtil.GetContentLength(aggregatedMessage));
-            Assert.Equal(bool.TrueString, aggregatedMessage.Headers.Get((AsciiString)"X-Test").ToString());
-            Assert.Equal(bool.TrueString, aggregatedMessage.TrailingHeaders.Get((AsciiString)"X-Trailer").ToString());
+            Assert.Equal(bool.TrueString, aggregatedMessage.Headers.Get((AsciiString)"X-Test", null)?.ToString());
+            Assert.Equal(bool.TrueString, aggregatedMessage.TrailingHeaders.Get((AsciiString)"X-Trailer", null)?.ToString());
             CheckContentBuffer(aggregatedMessage);
             var last = ch.ReadInbound<object>();
             Assert.Null(last);
@@ -90,7 +90,7 @@ namespace DotNetty.Codecs.Http.Tests
 
             var response = ch.ReadOutbound<IFullHttpResponse>();
             Assert.Equal(HttpResponseStatus.RequestEntityTooLarge, response.Status);
-            Assert.Equal("0", response.Headers.Get(HttpHeaderNames.ContentLength));
+            Assert.Equal("0", response.Headers.Get(HttpHeaderNames.ContentLength, null));
             Assert.False(ch.Open);
 
             try
@@ -186,7 +186,7 @@ namespace DotNetty.Codecs.Http.Tests
             Assert.NotNull(aggregatedMessage);
 
             Assert.Equal(chunk1.Content.ReadableBytes + chunk2.Content.ReadableBytes, HttpUtil.GetContentLength(aggregatedMessage));
-            Assert.Equal(bool.TrueString, aggregatedMessage.Headers.Get((AsciiString)"X-Test"));
+            Assert.Equal(bool.TrueString, aggregatedMessage.Headers.Get((AsciiString)"X-Test", null));
             CheckContentBuffer(aggregatedMessage);
             var last = ch.ReadInbound<object>();
             Assert.Null(last);
@@ -238,7 +238,7 @@ namespace DotNetty.Codecs.Http.Tests
             // The aggregator should respond with '413.'
             var response = ch.ReadOutbound<IFullHttpResponse>();
             Assert.Equal(HttpResponseStatus.RequestEntityTooLarge, response.Status);
-            Assert.Equal((AsciiString)"0", response.Headers.Get(HttpHeaderNames.ContentLength));
+            Assert.Equal((AsciiString)"0", response.Headers.Get(HttpHeaderNames.ContentLength, null));
 
             // An ill-behaving client could continue to send data without a respect, and such data should be discarded.
             Assert.False(ch.WriteInbound(chunk1));
@@ -281,7 +281,7 @@ namespace DotNetty.Codecs.Http.Tests
 
             var response = ch.ReadOutbound<IFullHttpResponse>();
             Assert.Equal(HttpResponseStatus.ExpectationFailed, response.Status);
-            Assert.Equal((AsciiString)"0", response.Headers.Get(HttpHeaderNames.ContentLength));
+            Assert.Equal((AsciiString)"0", response.Headers.Get(HttpHeaderNames.ContentLength, null));
             response.Release();
 
             if (close)
@@ -321,7 +321,7 @@ namespace DotNetty.Codecs.Http.Tests
 
             var response = ch.ReadOutbound<IFullHttpResponse>();
             Assert.Equal(HttpResponseStatus.RequestEntityTooLarge, response.Status);
-            Assert.Equal((AsciiString)"0", response.Headers.Get(HttpHeaderNames.ContentLength));
+            Assert.Equal((AsciiString)"0", response.Headers.Get(HttpHeaderNames.ContentLength, null));
 
             // Keep-alive is on by default in HTTP/1.1, so the connection should be still alive.
             Assert.True(ch.Open);
@@ -352,7 +352,7 @@ namespace DotNetty.Codecs.Http.Tests
 
             var response = ch.ReadOutbound<IFullHttpResponse>();
             Assert.Equal(HttpResponseStatus.RequestEntityTooLarge, response.Status);
-            Assert.Equal((AsciiString)"0", response.Headers.Get(HttpHeaderNames.ContentLength));
+            Assert.Equal((AsciiString)"0", response.Headers.Get(HttpHeaderNames.ContentLength, null));
 
             // We are forcing the connection closed if an expectation is exceeded.
             Assert.False(ch.Open);
@@ -379,7 +379,7 @@ namespace DotNetty.Codecs.Http.Tests
             // The aggregator should respond with '413'.
             var response = ch.ReadOutbound<IFullHttpResponse>();
             Assert.Equal(HttpResponseStatus.RequestEntityTooLarge, response.Status);
-            Assert.Equal((AsciiString)"0", response.Headers.Get(HttpHeaderNames.ContentLength));
+            Assert.Equal((AsciiString)"0", response.Headers.Get(HttpHeaderNames.ContentLength, null));
 
             // An ill-behaving client could continue to send data without a respect, and such data should be discarded.
             Assert.False(ch.WriteInbound(chunk1));
@@ -449,7 +449,7 @@ namespace DotNetty.Codecs.Http.Tests
             Assert.False(ch.WriteInbound(message));
             var response = ch.ReadOutbound<IHttpResponse>();
             Assert.Equal(HttpResponseStatus.RequestEntityTooLarge, response.Status);
-            Assert.Equal("0", response.Headers.Get(HttpHeaderNames.ContentLength));
+            Assert.Equal("0", response.Headers.Get(HttpHeaderNames.ContentLength, null));
 
             if (ServerShouldCloseConnection(message, response))
             {

--- a/test/DotNetty.Codecs.Http.Tests/HttpRequestDecoderTest.cs
+++ b/test/DotNetty.Codecs.Http.Tests/HttpRequestDecoderTest.cs
@@ -174,8 +174,8 @@ namespace DotNetty.Codecs.Http.Tests
                 + Crlf + Crlf;
             Assert.True(channel.WriteInbound(Unpooled.CopiedBuffer(Encoding.ASCII.GetBytes(Request))));
             var req = channel.ReadInbound<IHttpRequest>();
-            Assert.Equal("part1 newLinePart2", req.Headers.Get(new AsciiString("MyTestHeader")).ToString());
-            Assert.Equal("part21 newLinePart22", req.Headers.Get(new AsciiString("MyTestHeader2")).ToString());
+            Assert.Equal("part1 newLinePart2", req.Headers.Get(new AsciiString("MyTestHeader"), null).ToString());
+            Assert.Equal("part21 newLinePart22", req.Headers.Get(new AsciiString("MyTestHeader2"), null).ToString());
 
             var c = channel.ReadInbound<ILastHttpContent>();
             c.Release();
@@ -197,7 +197,7 @@ namespace DotNetty.Codecs.Http.Tests
 
             channel.WriteInbound(Unpooled.WrappedBuffer(data));
             var req = channel.ReadInbound<IHttpRequest>();
-            Assert.Equal("", req.Headers.Get((AsciiString)"EmptyHeader").ToString());
+            Assert.Equal("", req.Headers.Get((AsciiString)"EmptyHeader", null).ToString());
         }
 
         [Fact]
@@ -289,7 +289,7 @@ namespace DotNetty.Codecs.Http.Tests
             Assert.Equal(HttpVersion.Http11, req.ProtocolVersion);
             Assert.Equal("/some/path", req.Uri);
             Assert.Equal(1, req.Headers.Size);
-            Assert.True(AsciiString.ContentEqualsIgnoreCase((StringCharSequence)"localhost1", req.Headers.Get(HttpHeaderNames.Host)));
+            Assert.True(AsciiString.ContentEqualsIgnoreCase((StringCharSequence)"localhost1", req.Headers.Get(HttpHeaderNames.Host, null)));
             var cnt = channel.ReadInbound<ILastHttpContent>();
             cnt.Release();
 
@@ -299,8 +299,8 @@ namespace DotNetty.Codecs.Http.Tests
             Assert.Equal(HttpVersion.Http10, req.ProtocolVersion);
             Assert.Equal("/some/other/path", req.Uri);
             Assert.Equal(2, req.Headers.Size);
-            Assert.True(AsciiString.ContentEqualsIgnoreCase((StringCharSequence)"localhost2", req.Headers.Get(HttpHeaderNames.Host)));
-            Assert.True(AsciiString.ContentEqualsIgnoreCase((StringCharSequence)"0", req.Headers.Get(HttpHeaderNames.ContentLength)));
+            Assert.True(AsciiString.ContentEqualsIgnoreCase((StringCharSequence)"localhost2", req.Headers.Get(HttpHeaderNames.Host, null)));
+            Assert.True(AsciiString.ContentEqualsIgnoreCase((StringCharSequence)"0", req.Headers.Get(HttpHeaderNames.ContentLength, null)));
             cnt = channel.ReadInbound<ILastHttpContent>();
             cnt.Release();
 

--- a/test/DotNetty.Codecs.Http.Tests/HttpResponseDecoderTest.cs
+++ b/test/DotNetty.Codecs.Http.Tests/HttpResponseDecoderTest.cs
@@ -251,7 +251,7 @@ namespace DotNetty.Codecs.Http.Tests
             var res = ch.ReadInbound<IHttpResponse>();
             Assert.Same(HttpVersion.Http11, res.ProtocolVersion);
             Assert.Equal(HttpResponseStatus.OK, res.Status);
-            Assert.Equal("chunked", res.Headers.Get(HttpHeaderNames.TransferEncoding).ToString());
+            Assert.Equal("chunked", res.Headers.Get(HttpHeaderNames.TransferEncoding, null).ToString());
             res = ch.ReadInbound<IHttpResponse>();
             Assert.Null(res);
 
@@ -275,7 +275,7 @@ namespace DotNetty.Codecs.Http.Tests
             var res = ch.ReadInbound<IHttpResponse>();
             Assert.Same(HttpVersion.Http11, res.ProtocolVersion);
             Assert.Equal(HttpResponseStatus.OK, res.Status);
-            Assert.Equal("chunked", res.Headers.Get(HttpHeaderNames.TransferEncoding).ToString());
+            Assert.Equal("chunked", res.Headers.Get(HttpHeaderNames.TransferEncoding, null).ToString());
 
             // Read the partial content.
             var content = ch.ReadInbound<IHttpContent>();
@@ -353,7 +353,7 @@ namespace DotNetty.Codecs.Http.Tests
             var res = ch.ReadInbound<IHttpResponse>();
             Assert.Same(HttpVersion.Http11, res.ProtocolVersion);
             Assert.Equal(HttpResponseStatus.OK, res.Status);
-            Assert.Equal("h2=h2v2; Expires=Wed, 09-Jun-2021 10:18:14 GMT", res.Headers.Get((AsciiString)"X-Header").ToString());
+            Assert.Equal("h2=h2v2; Expires=Wed, 09-Jun-2021 10:18:14 GMT", res.Headers.Get((AsciiString)"X-Header", null).ToString());
             var content = ch.ReadInbound<IHttpContent>();
             Assert.Null(content);
 

--- a/test/DotNetty.Codecs.Http.Tests/HttpServerCodecTest.cs
+++ b/test/DotNetty.Codecs.Http.Tests/HttpServerCodecTest.cs
@@ -79,7 +79,7 @@ namespace DotNetty.Codecs.Http.Tests
 
             // Ensure the aggregator generates a full request.
             var req = ch.ReadInbound<IFullHttpRequest>();
-            Assert.Equal("1", req.Headers.Get(HttpHeaderNames.ContentLength).ToString());
+            Assert.Equal("1", req.Headers.Get(HttpHeaderNames.ContentLength, null).ToString());
             Assert.Equal(1, req.Content.ReadableBytes);
             Assert.Equal((byte)42, req.Content.ReadByte());
             req.Release();

--- a/test/DotNetty.Codecs.Http.Tests/HttpServerExpectContinueHandlerTest.cs
+++ b/test/DotNetty.Codecs.Http.Tests/HttpServerExpectContinueHandlerTest.cs
@@ -30,7 +30,7 @@ namespace DotNetty.Codecs.Http.Tests
             var response = channel.ReadOutbound<IHttpResponse>();
 
             Assert.Equal(HttpResponseStatus.Continue, response.Status);
-            Assert.Equal((AsciiString)"bar", response.Headers.Get((AsciiString)"foo"));
+            Assert.Equal((AsciiString)"bar", response.Headers.Get((AsciiString)"foo", null));
             ReferenceCountUtil.Release(response);
 
             var processedRequest = channel.ReadInbound<IHttpRequest>();

--- a/test/DotNetty.Codecs.Http.Tests/HttpUtilTest.cs
+++ b/test/DotNetty.Codecs.Http.Tests/HttpUtilTest.cs
@@ -30,8 +30,7 @@ namespace DotNetty.Codecs.Http.Tests
             headers.Add(new AsciiString("Foo"), new AsciiString("1"));
             headers.Add(new AsciiString("Foo"), new AsciiString("2"));
 
-            ICharSequence value = headers.Get(new AsciiString("Foo"));
-            Assert.NotNull(value);
+            Assert.True(headers.TryGet(new AsciiString("Foo"), out ICharSequence value));
             Assert.Equal("1", value.ToString());
 
             IList<ICharSequence> values = headers.GetAll(new AsciiString("Foo"));

--- a/test/DotNetty.Microbench/Headers/HeadersBenchmark.cs
+++ b/test/DotNetty.Microbench/Headers/HeadersBenchmark.cs
@@ -67,7 +67,7 @@ namespace DotNetty.Microbench.Headers
         {
             foreach (AsciiString name in this.httpNames)
             {
-                this.httpHeaders.Get(name);
+                this.httpHeaders.TryGet(name, out _);
             }
             return this.httpHeaders;
         }


### PR DESCRIPTION
Get semantic for headers replaced with TryGet which allows to get rid of class constraint on header value